### PR TITLE
Inliner ContentLoader

### DIFF
--- a/nais/dev-gcp/nais.yaml
+++ b/nais/dev-gcp/nais.yaml
@@ -9,7 +9,7 @@ spec:
   envFrom:
     - secret: tms-oversikt-mikrofrontend-secrets
   image: {{ image }}
-  port: 7100
+  port: 8080
   liveness:
     path: /tms-oversikt-mikrofrontend/internal/isAlive
     initialDelay: 10

--- a/nais/prod-gcp/nais.yaml
+++ b/nais/prod-gcp/nais.yaml
@@ -9,7 +9,7 @@ spec:
   envFrom:
     - secret: tms-oversikt-mikrofrontend-secrets
   image: {{ image }}
-  port: 7100
+  port: 8080
   liveness:
     path: /tms-oversikt-mikrofrontend/internal/isAlive
     initialDelay: 10

--- a/server/server.js
+++ b/server/server.js
@@ -18,4 +18,4 @@ server.get(`${basePath}/internal/isReady`, (req, res) => {
   res.sendStatus(200);
 });
 
-server.listen(7100, () => console.log("Server listening on port 7100"));
+server.listen(8080, () => console.log("Server listening on port 8080"));

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -44,10 +44,6 @@ function App() {
   const [aapManifest, isLoadingAapManifest] = useManifest(aapManifestUrl);
   const [aiaManifest, isLoadingAiaManifest] = useManifest(aiaManifestUrl);
 
-  if (isLoadingProfil || isLoadingAiaManifest || isLoadingAapManifest) {
-    return <ContentLoader />;
-  }
-
   const isAapBruker = profil?.microfrontends.includes("aap");
   const isArbeidssoker = arbeidssoker?.erArbeidssoker;
 
@@ -68,6 +64,7 @@ function App() {
         <Oppgaver />
         <Utkast />
       </div>
+      {isLoadingProfil || isLoadingAiaManifest || isLoadingAapManifest ? ContentLoader : null}
       <React.Suspense fallback={<ContentLoader />}>
         <ErrorBoundary setIsError={setIsError}>
           <Meldekort />


### PR DESCRIPTION
Det er ikke nødvendig å vente på profilen og manifestene for å rendre komponentene i appen. Ved å Inline ContentLoader så vil man rendre siden raskere.